### PR TITLE
Add link to the rendered version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ These resources can be used as git submodules in jekyll sites.
 
 Based on IOOS fork of ['Minimal Mistakes'](https://github.com/mmistakes/minimal-mistakes)
 Jekyll theme developed for IOOS Catalog documentation: https://ioos.github.io/catalog/
+
+See a rendered version at https://ioos.github.io/ioos_jekyll_theme


### PR DESCRIPTION
Adding a link to the rendered version of the theme at https://ioos.github.io/ioos_jekyll_theme
