### PR TITLE
Notebook gallery css

### DIFF
--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -1,0 +1,33 @@
+---
+layout: compress
+---
+
+{% include base_path %}
+
+<!doctype html>
+<html lang="{{ site.locale | slice: 0,2 | default: "en" }}" class="no-js">
+  <head>
+    {% include head.html %}
+    {% include head/custom.html %}
+  </head>
+
+  <body>
+
+    {% include browser-upgrade.html %}
+    {% include masthead.html %}
+
+    <div id="content-wrapper">
+      {{ content }}
+    </div>
+
+    <div class="page__footer">
+      <footer>
+        {% include footer/custom.html %}
+        {% include footer.html %}
+      </footer>
+    </div>
+
+    {% include scripts.html %}
+
+  </body>
+</html>

--- a/_sass/_gallery.scss
+++ b/_sass/_gallery.scss
@@ -1,0 +1,34 @@
+/* ==========================================================================
+   Notebook gallery
+   ========================================================================== */
+
+#content-wrapper {
+  padding-top: 80px;
+  padding-bottom: 80px;
+  padding-left: 100px;
+  padding-right: 100px;
+}
+
+#gallery {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+#gallery div {
+  border: 2px solid black;
+  border-radius: 10px;
+  flex: 1 1 80px;
+  margin: 10px;
+  padding: 5px;
+}
+
+#gallery div:hover {
+  border-width: 5px;
+  border-color: #FF7000;
+  margin: 7px;
+}
+
+#gallery div img {
+  width: 100%;
+  height: auto;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -29,6 +29,7 @@
 @import "footer";
 /* @import "syntax"; */
 @import "notebooks";
+@import "gallery";
 
 @import "forms";
 


### PR DESCRIPTION
@rsignell-usgs suggested that we should do a front page like Unidata's notebook gallery. This extra styling can produce something like:

![gallery](https://cloud.githubusercontent.com/assets/950575/19271556/8d72af06-8f9b-11e6-99e8-7b5527f8bada.png)
