### PR TITLE
do not resize border when highlighting

### DIFF
--- a/_sass/_gallery.scss
+++ b/_sass/_gallery.scss
@@ -16,9 +16,7 @@
 }
 
 #gallery div:hover {
-  border-width: 5px;
   border-color: #F3A536;
-  margin: 7px;
 }
 
 #gallery div img {


### PR DESCRIPTION
The gallery navigation has an odd feeling when hovering the boxes due to its resize+highlight. This changes the effects to only highlight, no resize, for a smoother experience.