### PR TITLE
increase font size

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -39,7 +39,7 @@ $type-size-3                : 1.563em;  // ~25.008px
 $type-size-4                : 1.25em;   // ~20px
 $type-size-5                : 1em;      // ~16px
 $type-size-6                : 0.75em;   // ~12px
-$type-size-7                : 0.6875em; // ~11px
+$type-size-7                : 15px; //was 0.6875em ~11px
 $type-size-8                : 0.625em;  // ~10px
 
 


### PR DESCRIPTION
The theme uses some fonts online and they got really small for some reason. By specifying it in pixels we can get around that. Note that I also made it bigger than the original 15 px instead of 11 px.